### PR TITLE
11 Implement cicd with Github actions

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -1,7 +1,7 @@
 name: pr-actions
 on: 
   push:
-    branches: [main]
+    branches: [11-implement-cicd-with-github-actions]
 jobs:
   run-cypress:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
-        with: 
-          node-version: '14'
+      # - uses: actions/setup-node@v3
+      #   with: 
+      #     node-version: '14'
       - run: npm install
       - run: npm run cypress:run

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -1,0 +1,11 @@
+name: pr-actions
+on: [pull_request]
+jobs:
+  run-cypress:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+        with: 
+          node-version: '14'
+      - run: npm install
+      - run: npm run cypress:run

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -1,5 +1,7 @@
 name: pr-actions
-on: [pull_request]
+on: 
+  push:
+    branches: [main]
 jobs:
   run-cypress:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -6,6 +6,7 @@ jobs:
   run-cypress:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with: 
           node-version: '14'

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -1,14 +1,12 @@
 name: pr-actions
 on: 
-  push:
-    branches: [11-implement-cicd-with-github-actions]
+  pull_request:
+    branches:
+      - 'main'
 jobs:
-  run-cypress:
+  Run-Cypress-PR:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # - uses: actions/setup-node@v3
-      #   with: 
-      #     node-version: '14'
       - run: npm install
       - run: npm run cypress:run

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "typescript": "^5.3.3"
   },
   "scripts": {
+    "cypress:run": "cypress run",
+    "cypress:open": "cypress open",
     "prettier": "prettier . --write"
   }
 }


### PR DESCRIPTION
Following changes were made...

- Github YML file added, which runs cypress suite upon PR to 'main'
- npm run scripts added to package.json to run the suite headless or interactive (cypress run/open respectively)