### PR TITLE
Implement initial page object architecture

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -1,5 +1,5 @@
 name: pr-actions
-on: 
+on:
   pull_request:
     branches:
       - 'main'

--- a/cypress/support/page-objects/ab-testing.po.ts
+++ b/cypress/support/page-objects/ab-testing.po.ts
@@ -1,0 +1,19 @@
+export class ABTestPage {
+  static PAGE_URL = 'abtest';
+  static HOME_LINK_TEXT = 'A/B Testing';
+
+  static HEADER_TEXT = 'A/B Test';
+  static BODY_TEXT = 'Also known as split testing';
+
+  static visit() {
+    cy.visit(this.PAGE_URL);
+  }
+
+  static getHeader() {
+    return cy.get('#content h3');
+  }
+
+  static getBody() {
+    return cy.get('#content p');
+  }
+}

--- a/cypress/support/page-objects/ab-testing.po.ts
+++ b/cypress/support/page-objects/ab-testing.po.ts
@@ -6,7 +6,7 @@ export class ABTestPage {
   static BODY_TEXT = 'Also known as split testing';
 
   static visit() {
-    cy.visit(this.PAGE_URL);
+    return cy.visit(this.PAGE_URL);
   }
 
   static getHeader() {

--- a/cypress/support/page-objects/add-remove-elements.po.ts
+++ b/cypress/support/page-objects/add-remove-elements.po.ts
@@ -3,7 +3,7 @@ export class AddRemoveElemPage {
   static HOME_LINK_TEXT = 'Add/Remove Elements';
 
   static visit() {
-    cy.visit(this.PAGE_URL);
+    return cy.visit(this.PAGE_URL);
   }
   static getAddButton() {
     return cy.get('#content > .example > button');

--- a/cypress/support/page-objects/add-remove-elements.po.ts
+++ b/cypress/support/page-objects/add-remove-elements.po.ts
@@ -1,0 +1,14 @@
+export class AddRemoveElemPage {
+  static PAGE_URL = 'add_remove_elements/';
+  static HOME_LINK_TEXT = 'Add/Remove Elements';
+
+  static visit() {
+    cy.visit(this.PAGE_URL);
+  }
+  static getAddButton() {
+    return cy.get('#content > .example > button');
+  }
+  static getDeleteButton() {
+    return cy.get('#elements > button');
+  }
+}

--- a/cypress/support/page-objects/basic-auth.po.ts
+++ b/cypress/support/page-objects/basic-auth.po.ts
@@ -1,0 +1,39 @@
+export class BasicAuthPage {
+  static PAGE_URL = 'basic_auth';
+
+  // Auth credentials used for class functions visitSuccess() and visitFailure()
+  private static AUTH_CREDS: Credentials = {
+    username: 'admin',
+    password: Cypress.env('BASIC_AUTH_PASSWORD')
+  };
+  private static BAD_CREDS: Credentials = {
+    username: 'wrong',
+    password: 'creds'
+  };
+
+  static visitSuccess() {
+    this.visit(this.AUTH_CREDS);
+  }
+
+  static visitFailure() {
+    this.visit(this.BAD_CREDS);
+  }
+
+  private static visit(creds: Credentials) {
+    // Visit page with required authentication credentials
+    cy.visit(this.PAGE_URL, { auth: creds, failOnStatusCode: false }); // failOnStatusCode: false required to stop test from auto-failing on negative case
+  }
+
+  static getHeader() {
+    return cy.get('div.example > h3');
+  }
+
+  static getBody() {
+    return cy.get('div.example > p');
+  }
+}
+
+interface Credentials {
+  username: string;
+  password: string;
+}

--- a/cypress/support/page-objects/basic-auth.po.ts
+++ b/cypress/support/page-objects/basic-auth.po.ts
@@ -1,5 +1,7 @@
 export class BasicAuthPage {
   static PAGE_URL = 'basic_auth';
+  static HEADER_TEXT = 'Basic Auth';
+  static BODY_TEXT = 'Congratulations!';
 
   // Auth credentials used for class functions visitSuccess() and visitFailure()
   private static AUTH_CREDS: Credentials = {

--- a/cypress/support/page-objects/broken-images.po.ts
+++ b/cypress/support/page-objects/broken-images.po.ts
@@ -8,7 +8,7 @@ export class BrokenImagesPage {
   private static AVATAR_IMG_SRC = 'img/avatar-blank.jpg';
 
   static visit() {
-    cy.visit(this.PAGE_URL);
+    return cy.visit(this.PAGE_URL);
   }
   static getBrokenImg1() {
     return cy.get(`img[src="${this.BROKEN_IMG_1_SRC}"]`);

--- a/cypress/support/page-objects/broken-images.po.ts
+++ b/cypress/support/page-objects/broken-images.po.ts
@@ -1,0 +1,22 @@
+export class BrokenImagesPage {
+  static PAGE_URL = 'broken_images';
+  static HOME_LINK_TEXT = 'Broken Images';
+
+  // Private variables for image sources (used to get elements in functions)
+  private static BROKEN_IMG_1_SRC = 'asdf.jpg';
+  private static BROKEN_IMG_2_SRC = 'asdf.jpg';
+  private static AVATAR_IMG_SRC = 'img/avatar-blank.jpg';
+
+  static visit() {
+    cy.visit(this.PAGE_URL);
+  }
+  static getBrokenImg1() {
+    return cy.get(`img[src="${this.BROKEN_IMG_1_SRC}"]`);
+  }
+  static getBrokenImg2() {
+    return cy.get(`img[src="${this.BROKEN_IMG_2_SRC}"]`);
+  }
+  static getAvatarImg() {
+    return cy.get(`img[src="${this.AVATAR_IMG_SRC}"]`);
+  }
+}

--- a/cypress/support/page-objects/home.po.ts
+++ b/cypress/support/page-objects/home.po.ts
@@ -1,0 +1,5 @@
+export class HomePage {
+  static visit() {
+    cy.visit('/');
+  }
+}

--- a/cypress/support/page-objects/home.po.ts
+++ b/cypress/support/page-objects/home.po.ts
@@ -1,5 +1,5 @@
 export class HomePage {
   static visit() {
-    cy.visit('/');
+    return cy.visit('/');
   }
 }

--- a/cypress/tests/ab-testing.cy.ts
+++ b/cypress/tests/ab-testing.cy.ts
@@ -1,35 +1,31 @@
-describe('A/B Testing Page', () => {
-  const PAGE_URL = 'abtest';
+import { ABTestPage } from '../support/page-objects/ab-testing.po';
+import { HomePage } from '../support/page-objects/home.po';
 
+describe('A/B Testing Page', () => {
   describe('Navigation', () => {
     it('Should be linked correctly from home page', () => {
       // Visit home page and click the correct link
-      cy.visit('/');
-      cy.get('a').contains('A/B Testing').click();
+      HomePage.visit();
+      cy.get('a').contains(ABTestPage.HOME_LINK_TEXT).click();
 
       // Assert correct page loads
-      cy.url().should('contain', PAGE_URL);
+      cy.url().should('contain', ABTestPage.PAGE_URL);
     });
   });
 
   describe('Functionality', () => {
-    const HEADER_TEXT = 'A/B Test';
-    const BODY_TEXT = 'Also known as split testing';
-
     it('Should successfully display page contents', () => {
       // Directly navigate to a/b testing page
-      cy.visit(PAGE_URL);
+      ABTestPage.visit();
 
       // Assert header contains correct text and is visible
-      cy.get('#content')
-        .find('h3')
-        .should('contain.text', HEADER_TEXT)
+      ABTestPage.getHeader()
+        .should('contain.text', ABTestPage.HEADER_TEXT)
         .and('be.visible');
 
       // Assert body contains correct text and is visible
-      cy.get('#content')
-        .find('p')
-        .should('contain.text', BODY_TEXT)
+      ABTestPage.getBody()
+        .should('contain.text', ABTestPage.BODY_TEXT)
         .and('be.visible');
     });
   });

--- a/cypress/tests/add-remove-elements.cy.ts
+++ b/cypress/tests/add-remove-elements.cy.ts
@@ -22,7 +22,7 @@ describe('Add/Remove Elements Page', () => {
     it('Should successfully add and remove element', () => {
       // Click 'Add Element' button and assert one new element was added
       AddRemoveElemPage.getAddButton().click();
-      cy.get('#elements').find('button').should('have.length', 1);
+      AddRemoveElemPage.getDeleteButton().should('have.length', 1);
 
       // Click created 'Delete' element and assert removal
       AddRemoveElemPage.getDeleteButton().click();

--- a/cypress/tests/add-remove-elements.cy.ts
+++ b/cypress/tests/add-remove-elements.cy.ts
@@ -1,31 +1,32 @@
-describe('Add/Remove Elements Page', () => {
-  const PAGE_URL = 'add_remove_elements/';
+import { HomePage } from '../support/page-objects/home.po';
+import { AddRemoveElemPage } from '../support/page-objects/add-remove-elements.po';
 
+describe('Add/Remove Elements Page', () => {
   describe('Navigation', () => {
     it('Should be linked correctly from home page', () => {
       // Visit home page and click the correct link
-      cy.visit('/');
-      cy.contains('Add/Remove Elements').click();
+      HomePage.visit();
+      cy.contains(AddRemoveElemPage.HOME_LINK_TEXT).click();
 
       // Assert correct page loads
-      cy.url().should('contain', PAGE_URL);
+      cy.url().should('contain', AddRemoveElemPage.PAGE_URL);
     });
   });
 
   describe('Functionality', () => {
     beforeEach(() => {
       // Navigate directly to add/remove elements page
-      cy.visit(PAGE_URL);
+      AddRemoveElemPage.visit();
     });
 
     it('Should successfully add and remove element', () => {
       // Click 'Add Element' button and assert one new element was added
-      cy.get('button').contains('Add Element').click();
+      AddRemoveElemPage.getAddButton().click();
       cy.get('#elements').find('button').should('have.length', 1);
 
       // Click created 'Delete' element and assert removal
-      cy.get('button').contains('Delete').click();
-      cy.get('button').contains('Delete').should('not.exist');
+      AddRemoveElemPage.getDeleteButton().click();
+      AddRemoveElemPage.getDeleteButton().should('not.exist');
     });
 
     it('Should successfully add and remove multiple elements', () => {
@@ -34,19 +35,19 @@ describe('Add/Remove Elements Page', () => {
 
       // Click 'Add Element' button the number of times defined in ELEMENT_NUM
       cy.loop(ELEMENT_NUM).each(() => {
-        cy.get('button').contains('Add Element').click();
+        AddRemoveElemPage.getAddButton().click();
       });
 
       // Assert the correct number of elements were added
-      cy.get('#elements').find('button').should('have.length', ELEMENT_NUM);
+      AddRemoveElemPage.getDeleteButton().should('have.length', ELEMENT_NUM);
 
       // Click each 'Delete' element added
       cy.loop(ELEMENT_NUM).each(() => {
-        cy.get('#elements > button').first().click();
+        AddRemoveElemPage.getDeleteButton().first().click();
       });
 
       // Assert no 'Delete' elements remain after all are clicked
-      cy.get('button').contains('Delete').should('not.exist');
+      AddRemoveElemPage.getDeleteButton().should('not.exist');
     });
   });
 });

--- a/cypress/tests/basic-auth.cy.ts
+++ b/cypress/tests/basic-auth.cy.ts
@@ -7,10 +7,10 @@ describe('Basic Auth Page Functionality', () => {
 
     // Assert successful authentication by visibility of the contents on the page
     BasicAuthPage.getHeader()
-      .should('contain.text', 'Basic Auth')
+      .should('contain.text', BasicAuthPage.HEADER_TEXT)
       .and('be.visible');
     BasicAuthPage.getBody()
-      .should('contain.text', 'Congratulations!')
+      .should('contain.text', BasicAuthPage.BODY_TEXT)
       .and('be.visible');
   });
 

--- a/cypress/tests/basic-auth.cy.ts
+++ b/cypress/tests/basic-auth.cy.ts
@@ -1,21 +1,15 @@
-const PAGE_URL = 'basic_auth';
-const AUTH_CREDS = {
-  username: 'admin',
-  password: Cypress.env('BASIC_AUTH_PASSWORD')
-};
-const BAD_CREDS = {
-  username: 'wrong',
-  password: 'creds'
-};
+import { BasicAuthPage } from '../support/page-objects/basic-auth.po';
 
 describe('Basic Auth Page Functionality', () => {
   it('Should be able to access page with correct credentials', () => {
-    // Visit page with authentication options loaded in (cannot interact with login browser prompt)
-    cy.visit(PAGE_URL, { auth: AUTH_CREDS });
+    // Visit page with correct authentication options loaded in (cannot interact with login browser prompt)
+    BasicAuthPage.visitSuccess();
 
     // Assert successful authentication by visibility of the contents on the page
-    cy.get('h3').contains('Basic Auth').should('be.visible');
-    cy.get('#content > .example > p')
+    BasicAuthPage.getHeader()
+      .should('contain.text', 'Basic Auth')
+      .and('be.visible');
+    BasicAuthPage.getBody()
       .should('contain.text', 'Congratulations!')
       .and('be.visible');
   });
@@ -23,7 +17,7 @@ describe('Basic Auth Page Functionality', () => {
   // This test is being skipped due to a technical limitation with Cypress. The negative case causes an authentication
   // pop-up in the browser, which cannot be interacted with. This test passes with manual intervention
   it.skip('Should not be able to access page with incorrect authentication credentials', () => {
-    cy.visit(PAGE_URL, { auth: BAD_CREDS, failOnStatusCode: false }); // failOnStatusCode: false required to stop test from auto-failing
+    BasicAuthPage.visitFailure();
     cy.get('body').contains('Not authorized').should('be.visible');
   });
 });

--- a/cypress/tests/broken-images.cy.ts
+++ b/cypress/tests/broken-images.cy.ts
@@ -15,7 +15,7 @@ describe('Broken Images Page', () => {
 
   describe('Functionality', () => {
     it('Should display the expected images', () => {
-      // Visit URL and assert that each expected image is visible on the page
+      // Visit page and assert that each expected image is visible
       BrokenImagesPage.visit();
       BrokenImagesPage.getBrokenImg1().should('be.visible');
       BrokenImagesPage.getBrokenImg2().should('be.visible');

--- a/cypress/tests/broken-images.cy.ts
+++ b/cypress/tests/broken-images.cy.ts
@@ -1,27 +1,25 @@
-describe('Broken Images Page', () => {
-  const PAGE_URL = 'broken_images';
-  const BROKEN_IMG_1_SRC = 'asdf.jpg';
-  const BROKEN_IMG_2_SRC = 'asdf.jpg';
-  const AVATAR_IMG_SRC = 'img/avatar-blank.jpg';
+import { HomePage } from '../support/page-objects/home.po';
+import { BrokenImagesPage } from '../support/page-objects/broken-images.po';
 
+describe('Broken Images Page', () => {
   describe('Navigation', () => {
     it('Should be linked correctly from home page', () => {
       // Visit home page and click the correct link
-      cy.visit('/');
-      cy.get('a').contains('Broken Images').click();
+      HomePage.visit();
+      cy.get('a').contains(BrokenImagesPage.HOME_LINK_TEXT).click();
 
       // Assert correct page loads
-      cy.url().should('contain', PAGE_URL);
+      cy.url().should('contain', BrokenImagesPage.PAGE_URL);
     });
   });
 
   describe('Functionality', () => {
     it('Should display the expected images', () => {
       // Visit URL and assert that each expected image is visible on the page
-      cy.visit(PAGE_URL);
-      cy.get(`img[src="${BROKEN_IMG_1_SRC}"]`).should('be.visible');
-      cy.get(`img[src="${BROKEN_IMG_2_SRC}"]`).should('be.visible');
-      cy.get(`img[src="${AVATAR_IMG_SRC}"]`).should('be.visible');
+      BrokenImagesPage.visit();
+      BrokenImagesPage.getBrokenImg1().should('be.visible');
+      BrokenImagesPage.getBrokenImg2().should('be.visible');
+      BrokenImagesPage.getAvatarImg().should('be.visible');
     });
   });
 });


### PR DESCRIPTION
This is the first big "refactor" ticket in this project, setting up the foundations for Page Object Architecture, using classes with static vars/functions

This PR consists of the following changes...
- Addition of `page-objects/` folder under `cypress/support/`
- Addition of one page object (.po.ts) file for each current page being tested
- Updates to each existing spec, to use the new page object format
- Prettier update for github actions PR yml