### PR TITLE
Move navigation tests into dedicated spec

### DIFF
--- a/cypress/data/interfaces/PageDetails.ts
+++ b/cypress/data/interfaces/PageDetails.ts
@@ -1,0 +1,9 @@
+/**
+ * Custom data model to hold a page's home page link text and URL
+ * @string linkText
+ * @string pageUrl
+ */
+interface PageDetails {
+  linkText: string;
+  pageUrl: string;
+}

--- a/cypress/support/page-objects/ab-testing.po.ts
+++ b/cypress/support/page-objects/ab-testing.po.ts
@@ -1,12 +1,13 @@
 export class ABTestPage {
-  static PAGE_URL = 'abtest';
-  static HOME_LINK_TEXT = 'A/B Testing';
-
+  static details: PageDetails = {
+    linkText: 'A/B Testing',
+    pageUrl: 'abtest'
+  };
   static HEADER_TEXT = 'A/B Test';
   static BODY_TEXT = 'Also known as split testing';
 
   static visit() {
-    return cy.visit(this.PAGE_URL);
+    return cy.visit(this.details.pageUrl);
   }
 
   static getHeader() {

--- a/cypress/support/page-objects/add-remove-elements.po.ts
+++ b/cypress/support/page-objects/add-remove-elements.po.ts
@@ -1,9 +1,11 @@
 export class AddRemoveElemPage {
-  static PAGE_URL = 'add_remove_elements/';
-  static HOME_LINK_TEXT = 'Add/Remove Elements';
+  static details: PageDetails = {
+    linkText: 'Add/Remove Elements',
+    pageUrl: 'add_remove_elements/'
+  };
 
   static visit() {
-    return cy.visit(this.PAGE_URL);
+    return cy.visit(this.details.pageUrl);
   }
   static getAddButton() {
     return cy.get('#content > .example > button');

--- a/cypress/support/page-objects/basic-auth.po.ts
+++ b/cypress/support/page-objects/basic-auth.po.ts
@@ -1,5 +1,8 @@
 export class BasicAuthPage {
-  static PAGE_URL = 'basic_auth';
+  static details: PageDetails = {
+    linkText: 'Basic Auth',
+    pageUrl: 'basic_auth'
+  };
   static HEADER_TEXT = 'Basic Auth';
   static BODY_TEXT = 'Congratulations!';
 
@@ -23,7 +26,8 @@ export class BasicAuthPage {
 
   private static visit(creds: Credentials) {
     // Visit page with required authentication credentials
-    cy.visit(this.PAGE_URL, { auth: creds, failOnStatusCode: false }); // failOnStatusCode: false required to stop test from auto-failing on negative case
+    // failOnStatusCode: false required to stop test from auto-failing on negative case
+    cy.visit(this.details.pageUrl, { auth: creds, failOnStatusCode: false });
   }
 
   static getHeader() {

--- a/cypress/support/page-objects/broken-images.po.ts
+++ b/cypress/support/page-objects/broken-images.po.ts
@@ -1,14 +1,15 @@
 export class BrokenImagesPage {
-  static PAGE_URL = 'broken_images';
-  static HOME_LINK_TEXT = 'Broken Images';
-
+  static details: PageDetails = {
+    linkText: 'Broken Images',
+    pageUrl: 'broken_images'
+  };
   // Private variables for image sources (used to get elements in functions)
   private static BROKEN_IMG_1_SRC = 'asdf.jpg';
   private static BROKEN_IMG_2_SRC = 'asdf.jpg';
   private static AVATAR_IMG_SRC = 'img/avatar-blank.jpg';
 
   static visit() {
-    return cy.visit(this.PAGE_URL);
+    return cy.visit(this.details.pageUrl);
   }
   static getBrokenImg1() {
     return cy.get(`img[src="${this.BROKEN_IMG_1_SRC}"]`);

--- a/cypress/support/page-objects/home.po.ts
+++ b/cypress/support/page-objects/home.po.ts
@@ -1,5 +1,15 @@
+import { ABTestPage } from './ab-testing.po';
+import { AddRemoveElemPage } from './add-remove-elements.po';
+import { BrokenImagesPage } from './broken-images.po';
+
 export class HomePage {
   static visit() {
     return cy.visit('/');
   }
+
+  static pageDetailsList: PageDetails[] = [
+    ABTestPage.details,
+    AddRemoveElemPage.details,
+    BrokenImagesPage.details
+  ];
 }

--- a/cypress/tests/ab-testing.cy.ts
+++ b/cypress/tests/ab-testing.cy.ts
@@ -1,32 +1,18 @@
 import { ABTestPage } from '../support/page-objects/ab-testing.po';
-import { HomePage } from '../support/page-objects/home.po';
 
-describe('A/B Testing Page', () => {
-  describe('Navigation', () => {
-    it('Should be linked correctly from home page', () => {
-      // Visit home page and click the correct link
-      HomePage.visit();
-      cy.get('a').contains(ABTestPage.HOME_LINK_TEXT).click();
+describe('A/B Testing Page Functionality', () => {
+  it('Should successfully display page contents', () => {
+    // Directly navigate to a/b testing page
+    ABTestPage.visit();
 
-      // Assert correct page loads
-      cy.url().should('contain', ABTestPage.PAGE_URL);
-    });
-  });
+    // Assert header contains correct text and is visible
+    ABTestPage.getHeader()
+      .should('contain.text', ABTestPage.HEADER_TEXT)
+      .and('be.visible');
 
-  describe('Functionality', () => {
-    it('Should successfully display page contents', () => {
-      // Directly navigate to a/b testing page
-      ABTestPage.visit();
-
-      // Assert header contains correct text and is visible
-      ABTestPage.getHeader()
-        .should('contain.text', ABTestPage.HEADER_TEXT)
-        .and('be.visible');
-
-      // Assert body contains correct text and is visible
-      ABTestPage.getBody()
-        .should('contain.text', ABTestPage.BODY_TEXT)
-        .and('be.visible');
-    });
+    // Assert body contains correct text and is visible
+    ABTestPage.getBody()
+      .should('contain.text', ABTestPage.BODY_TEXT)
+      .and('be.visible');
   });
 });

--- a/cypress/tests/add-remove-elements.cy.ts
+++ b/cypress/tests/add-remove-elements.cy.ts
@@ -1,53 +1,39 @@
-import { HomePage } from '../support/page-objects/home.po';
 import { AddRemoveElemPage } from '../support/page-objects/add-remove-elements.po';
 
-describe('Add/Remove Elements Page', () => {
-  describe('Navigation', () => {
-    it('Should be linked correctly from home page', () => {
-      // Visit home page and click the correct link
-      HomePage.visit();
-      cy.contains(AddRemoveElemPage.HOME_LINK_TEXT).click();
-
-      // Assert correct page loads
-      cy.url().should('contain', AddRemoveElemPage.PAGE_URL);
-    });
+describe('Add/Remove Elements Page Functionality', () => {
+  beforeEach(() => {
+    // Navigate directly to add/remove elements page
+    AddRemoveElemPage.visit();
   });
 
-  describe('Functionality', () => {
-    beforeEach(() => {
-      // Navigate directly to add/remove elements page
-      AddRemoveElemPage.visit();
-    });
+  it('Should successfully add and remove element', () => {
+    // Click 'Add Element' button and assert one new element was added
+    AddRemoveElemPage.getAddButton().click();
+    AddRemoveElemPage.getDeleteButton().should('have.length', 1);
 
-    it('Should successfully add and remove element', () => {
-      // Click 'Add Element' button and assert one new element was added
+    // Click created 'Delete' element and assert removal
+    AddRemoveElemPage.getDeleteButton().click();
+    AddRemoveElemPage.getDeleteButton().should('not.exist');
+  });
+
+  it('Should successfully add and remove multiple elements', () => {
+    // Variable to hold number of elements to add
+    const ELEMENT_NUM: number = 10;
+
+    // Click 'Add Element' button the number of times defined in ELEMENT_NUM
+    cy.loop(ELEMENT_NUM).each(() => {
       AddRemoveElemPage.getAddButton().click();
-      AddRemoveElemPage.getDeleteButton().should('have.length', 1);
-
-      // Click created 'Delete' element and assert removal
-      AddRemoveElemPage.getDeleteButton().click();
-      AddRemoveElemPage.getDeleteButton().should('not.exist');
     });
 
-    it('Should successfully add and remove multiple elements', () => {
-      // Variable to hold number of elements to add
-      const ELEMENT_NUM: number = 10;
+    // Assert the correct number of elements were added
+    AddRemoveElemPage.getDeleteButton().should('have.length', ELEMENT_NUM);
 
-      // Click 'Add Element' button the number of times defined in ELEMENT_NUM
-      cy.loop(ELEMENT_NUM).each(() => {
-        AddRemoveElemPage.getAddButton().click();
-      });
-
-      // Assert the correct number of elements were added
-      AddRemoveElemPage.getDeleteButton().should('have.length', ELEMENT_NUM);
-
-      // Click each 'Delete' element added
-      cy.loop(ELEMENT_NUM).each(() => {
-        AddRemoveElemPage.getDeleteButton().first().click();
-      });
-
-      // Assert no 'Delete' elements remain after all are clicked
-      AddRemoveElemPage.getDeleteButton().should('not.exist');
+    // Click each 'Delete' element added
+    cy.loop(ELEMENT_NUM).each(() => {
+      AddRemoveElemPage.getDeleteButton().first().click();
     });
+
+    // Assert no 'Delete' elements remain after all are clicked
+    AddRemoveElemPage.getDeleteButton().should('not.exist');
   });
 });

--- a/cypress/tests/broken-images.cy.ts
+++ b/cypress/tests/broken-images.cy.ts
@@ -1,25 +1,11 @@
-import { HomePage } from '../support/page-objects/home.po';
 import { BrokenImagesPage } from '../support/page-objects/broken-images.po';
 
-describe('Broken Images Page', () => {
-  describe('Navigation', () => {
-    it('Should be linked correctly from home page', () => {
-      // Visit home page and click the correct link
-      HomePage.visit();
-      cy.get('a').contains(BrokenImagesPage.HOME_LINK_TEXT).click();
-
-      // Assert correct page loads
-      cy.url().should('contain', BrokenImagesPage.PAGE_URL);
-    });
-  });
-
-  describe('Functionality', () => {
-    it('Should display the expected images', () => {
-      // Visit page and assert that each expected image is visible
-      BrokenImagesPage.visit();
-      BrokenImagesPage.getBrokenImg1().should('be.visible');
-      BrokenImagesPage.getBrokenImg2().should('be.visible');
-      BrokenImagesPage.getAvatarImg().should('be.visible');
-    });
+describe('Broken Images Page Functionality', () => {
+  it('Should display the expected images', () => {
+    // Visit page and assert that each expected image is visible
+    BrokenImagesPage.visit();
+    BrokenImagesPage.getBrokenImg1().should('be.visible');
+    BrokenImagesPage.getBrokenImg2().should('be.visible');
+    BrokenImagesPage.getAvatarImg().should('be.visible');
   });
 });

--- a/cypress/tests/home.cy.ts
+++ b/cypress/tests/home.cy.ts
@@ -1,0 +1,15 @@
+import { HomePage } from '../support/page-objects/home.po';
+
+describe('Home Page Functionality', () => {
+  // Page Details defined in home page object. This test will run for all entries in page details array.
+  HomePage.pageDetailsList.forEach((page: PageDetails) => {
+    it(`Should assert successful navigation to ${page.linkText} page`, () => {
+      // Visit home page and click the correct link
+      HomePage.visit();
+      cy.contains(page.linkText).click();
+
+      // Assert correct page loads
+      cy.url().should('contain', page.pageUrl);
+    });
+  });
+});


### PR DESCRIPTION
Resolves #19

The following was changed as part of this ticket:
- PageDetails interface created, along with directory structure for data types (`data/interfaces/*`)
- Restructure each page object's PAGE_URL and HOME_LINK_TEXT variables into the new PageDetails type
- Expand home page object to take in an array of page detail objects from each existing page
- Create new home.cy.ts spec file, which loops the page detail array from the home page object
- Remove home navigation tests from the separate page specs and restructure describes