### PR TITLE
#25: Add UI test for Form Authentication (UI Login) page

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -12,3 +12,4 @@ jobs:
       - run: npm run cypress:run
         env:
           CYPRESS_BASIC_AUTH_PASSWORD: ${{ secrets.CYPRESS_BASIC_AUTH_PASSWORD }}
+          CYPRESS_FORM_AUTH_PASSWORD: ${{ secrets.CYPRESS_FORM_AUTH_PASSWORD }}

--- a/cypress/data/interfaces/Credentials.ts
+++ b/cypress/data/interfaces/Credentials.ts
@@ -1,0 +1,9 @@
+/**
+ * Custom data model to hold a user's authentication credentials
+ * @string username
+ * @string password
+ */
+interface Credentials {
+  username: string;
+  password: string;
+}

--- a/cypress/data/interfaces/PageDetails.ts
+++ b/cypress/data/interfaces/PageDetails.ts
@@ -1,9 +1,9 @@
 /**
  * Custom data model to hold a page's home page link text and URL
- * @string linkText
- * @string pageUrl
+ * @string linkText - OPTIONAL: Home page link text
+ * @string pageUrl - URL extension for page
  */
 interface PageDetails {
-  linkText: string;
+  linkText?: string;
   pageUrl: string;
 }

--- a/cypress/support/page-objects/basic-auth.po.ts
+++ b/cypress/support/page-objects/basic-auth.po.ts
@@ -38,8 +38,3 @@ export class BasicAuthPage {
     return cy.get('div.example > p');
   }
 }
-
-interface Credentials {
-  username: string;
-  password: string;
-}

--- a/cypress/support/page-objects/form-auth.po.ts
+++ b/cypress/support/page-objects/form-auth.po.ts
@@ -1,0 +1,36 @@
+export class FormAuthPage {
+  static details: PageDetails = {
+    linkText: 'Form Authentication',
+    pageUrl: 'login'
+  };
+
+  static AUTH_CREDS: Credentials = {
+    username: 'tomsmith',
+    password: Cypress.env('FORM_AUTH_PASSWORD')
+  };
+
+  static BAD_CREDS: Credentials = {
+    username: 'wrong',
+    password: 'wrong'
+  };
+
+  static visit() {
+    return cy.visit(this.details.pageUrl);
+  }
+
+  static enterUsername(username: string) {
+    return cy.get('#username').type(username);
+  }
+
+  static enterPassword(password: string) {
+    return cy.get('#password').type(password);
+  }
+
+  static clickSubmitButton() {
+    return cy.get('button[type="submit"]').click();
+  }
+
+  static getStatusBanner() {
+    return cy.get('#flash');
+  }
+}

--- a/cypress/support/page-objects/home.po.ts
+++ b/cypress/support/page-objects/home.po.ts
@@ -1,6 +1,7 @@
 import { ABTestPage } from './ab-testing.po';
 import { AddRemoveElemPage } from './add-remove-elements.po';
 import { BrokenImagesPage } from './broken-images.po';
+import { FormAuthPage } from './form-auth.po';
 
 export class HomePage {
   static visit() {
@@ -10,6 +11,7 @@ export class HomePage {
   static pageDetailsList: PageDetails[] = [
     ABTestPage.details,
     AddRemoveElemPage.details,
-    BrokenImagesPage.details
+    BrokenImagesPage.details,
+    FormAuthPage.details
   ];
 }

--- a/cypress/support/page-objects/secure.po.ts
+++ b/cypress/support/page-objects/secure.po.ts
@@ -1,0 +1,13 @@
+export class SecurePage {
+  static details: PageDetails = {
+    pageUrl: 'secure'
+  };
+
+  static getStatusBanner() {
+    return cy.get('#flash');
+  }
+
+  static clickLogoutButton() {
+    return cy.get('a.button[href="/logout"]').click();
+  }
+}

--- a/cypress/tests/form-auth.cy.ts
+++ b/cypress/tests/form-auth.cy.ts
@@ -1,0 +1,36 @@
+import { FormAuthPage } from '../support/page-objects/form-auth.po';
+import { SecurePage } from '../support/page-objects/secure.po';
+
+describe('Form Authentication Page Functionality', () => {
+  beforeEach(() => {
+    // Navigate to page
+    FormAuthPage.visit();
+  });
+
+  it('Should successfully submit login form with valid credentials, then log out', () => {
+    // Complete a successful login
+    FormAuthPage.enterUsername(FormAuthPage.AUTH_CREDS.username);
+    FormAuthPage.enterPassword(FormAuthPage.AUTH_CREDS.password);
+    FormAuthPage.clickSubmitButton();
+
+    // Assert on successful form submission
+    cy.url().should('contain', SecurePage.details.pageUrl);
+    SecurePage.getStatusBanner().should('have.class', 'success');
+
+    // Click log out button
+    SecurePage.clickLogoutButton();
+
+    // Assert on successful logout
+    FormAuthPage.getStatusBanner().should('have.class', 'success');
+  });
+
+  it('Should display error when submitting login form with invalid credentials', () => {
+    // Complete an invalid login submission
+    FormAuthPage.enterUsername('Invalid');
+    FormAuthPage.enterPassword('Invalid');
+    FormAuthPage.clickSubmitButton();
+
+    // Assert on invalid form submission
+    FormAuthPage.getStatusBanner().should('have.class', 'error');
+  });
+});


### PR DESCRIPTION
Resolves #25 

The following was changed as part of this ticket:
- Add authentication password variable to pr yml
- Add interface file for Credentials and alter PageDetails to make linkText optional
- Add page objects for Form Authentication and Secure pages (Secure page is landing page after successful log in)
- Add UI test spec for Form Authentication page functionality
- Add Form Authentication page details to home page object