### PR TITLE
#33: Pull data back into auth specs and restructure basic-auth page object

### DIFF
--- a/cypress/support/page-objects/basic-auth.po.ts
+++ b/cypress/support/page-objects/basic-auth.po.ts
@@ -6,28 +6,13 @@ export class BasicAuthPage {
   static HEADER_TEXT = 'Basic Auth';
   static BODY_TEXT = 'Congratulations!';
 
-  // Auth credentials used for class functions visitSuccess() and visitFailure()
-  private static AUTH_CREDS: Credentials = {
-    username: 'admin',
-    password: Cypress.env('BASIC_AUTH_PASSWORD')
-  };
-  private static BAD_CREDS: Credentials = {
-    username: 'wrong',
-    password: 'creds'
-  };
-
-  static visitSuccess() {
-    this.visit(this.AUTH_CREDS);
-  }
-
-  static visitFailure() {
-    this.visit(this.BAD_CREDS);
-  }
-
-  private static visit(creds: Credentials) {
+  static visit(username: string, password: string) {
     // Visit page with required authentication credentials
     // failOnStatusCode: false required to stop test from auto-failing on negative case
-    cy.visit(this.details.pageUrl, { auth: creds, failOnStatusCode: false });
+    cy.visit(this.details.pageUrl, {
+      auth: { username, password },
+      failOnStatusCode: false
+    });
   }
 
   static getHeader() {

--- a/cypress/support/page-objects/form-auth.po.ts
+++ b/cypress/support/page-objects/form-auth.po.ts
@@ -4,16 +4,6 @@ export class FormAuthPage {
     pageUrl: 'login'
   };
 
-  static AUTH_CREDS: Credentials = {
-    username: 'tomsmith',
-    password: Cypress.env('FORM_AUTH_PASSWORD')
-  };
-
-  static BAD_CREDS: Credentials = {
-    username: 'wrong',
-    password: 'wrong'
-  };
-
   static visit() {
     return cy.visit(this.details.pageUrl);
   }

--- a/cypress/tests/basic-auth.cy.ts
+++ b/cypress/tests/basic-auth.cy.ts
@@ -1,9 +1,15 @@
 import { BasicAuthPage } from '../support/page-objects/basic-auth.po';
 
+// Valid auth credentials
+const VALID_CREDS: Credentials = {
+  username: 'admin',
+  password: Cypress.env('BASIC_AUTH_PASSWORD')
+};
+
 describe('Basic Auth Page Functionality', () => {
   it('Should be able to access page with correct credentials', () => {
     // Visit page with correct authentication options loaded in (cannot interact with login browser prompt)
-    BasicAuthPage.visitSuccess();
+    BasicAuthPage.visit(VALID_CREDS.username, VALID_CREDS.password);
 
     // Assert successful authentication by visibility of the contents on the page
     BasicAuthPage.getHeader()
@@ -14,10 +20,8 @@ describe('Basic Auth Page Functionality', () => {
       .and('be.visible');
   });
 
-  // This test is being skipped due to a technical limitation with Cypress. The negative case causes an authentication
-  // pop-up in the browser, which cannot be interacted with. This test passes with manual intervention
-  it.skip('Should not be able to access page with incorrect authentication credentials', () => {
-    BasicAuthPage.visitFailure();
+  it('Should not be able to access page with incorrect authentication credentials', () => {
+    BasicAuthPage.visit('Invalid', 'Invalid');
     cy.get('body').contains('Not authorized').should('be.visible');
   });
 });

--- a/cypress/tests/form-auth.cy.ts
+++ b/cypress/tests/form-auth.cy.ts
@@ -1,6 +1,12 @@
 import { FormAuthPage } from '../support/page-objects/form-auth.po';
 import { SecurePage } from '../support/page-objects/secure.po';
 
+// Valid credentials for login
+const AUTH_CREDS: Credentials = {
+  username: 'tomsmith',
+  password: Cypress.env('FORM_AUTH_PASSWORD')
+};
+
 describe('Form Authentication Page Functionality', () => {
   beforeEach(() => {
     // Navigate to page
@@ -9,8 +15,8 @@ describe('Form Authentication Page Functionality', () => {
 
   it('Should successfully submit login form with valid credentials, then log out', () => {
     // Complete a successful login
-    FormAuthPage.enterUsername(FormAuthPage.AUTH_CREDS.username);
-    FormAuthPage.enterPassword(FormAuthPage.AUTH_CREDS.password);
+    FormAuthPage.enterUsername(AUTH_CREDS.username);
+    FormAuthPage.enterPassword(AUTH_CREDS.password);
     FormAuthPage.clickSubmitButton();
 
     // Assert on successful form submission


### PR DESCRIPTION
Resolves #33 

The following was changed as part of this ticket:
- Valid auth credentials moved from page objects into specs
- basic-auth visit command structure re-organized. Now a single visit command that takes in credentials
- unskip the previously failing negative case for basic-auth spec