### PR TITLE
#24: Add file-upload spec and page object

### DIFF
--- a/cypress/data/files/TestUploadFile.txt
+++ b/cypress/data/files/TestUploadFile.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/cypress/support/page-objects/ab-testing.po.ts
+++ b/cypress/support/page-objects/ab-testing.po.ts
@@ -5,15 +5,15 @@ export class ABTestPage {
     pageUrl: 'abtest'
   };
 
-  // Selectors
+  // Page Data
+  static HEADER_TEXT = 'A/B Test';
+  static BODY_TEXT = 'Also known as split testing';
+
+  // Page Selectors
   private static selectors = {
     header: '#content h3',
     body: '#content p'
   };
-
-  // Page Text
-  static HEADER_TEXT = 'A/B Test';
-  static BODY_TEXT = 'Also known as split testing';
 
   // Page Functions
   static visit() {

--- a/cypress/support/page-objects/basic-auth.po.ts
+++ b/cypress/support/page-objects/basic-auth.po.ts
@@ -5,15 +5,15 @@ export class BasicAuthPage {
     pageUrl: 'basic_auth'
   };
 
+  // Page Data
+  static HEADER_TEXT = 'Basic Auth';
+  static BODY_TEXT = 'Congratulations!';
+
   // Page Selectors
   private static selectors = {
     header: 'div.example > h3',
     body: 'div.example > p'
   };
-
-  // Page Text
-  static HEADER_TEXT = 'Basic Auth';
-  static BODY_TEXT = 'Congratulations!';
 
   // Page Functions
   static visit(username: string, password: string) {

--- a/cypress/support/page-objects/broken-images.po.ts
+++ b/cypress/support/page-objects/broken-images.po.ts
@@ -5,7 +5,7 @@ export class BrokenImagesPage {
     pageUrl: 'broken_images'
   };
 
-  // Private variables for image sources (used in selectors)
+  // Page Data
   private static BROKEN_IMG_1_SRC = 'asdf.jpg';
   private static BROKEN_IMG_2_SRC = 'asdf.jpg';
   private static AVATAR_IMG_SRC = 'img/avatar-blank.jpg';

--- a/cypress/support/page-objects/file-upload.po.ts
+++ b/cypress/support/page-objects/file-upload.po.ts
@@ -1,0 +1,41 @@
+export class FileUploadPage {
+  // Page Details
+  static details: PageDetails = {
+    linkText: 'File Upload',
+    pageUrl: 'upload'
+  };
+
+  // Page Data
+  static ERROR_TEXT = 'Internal Server Error';
+
+  // Page Selectors
+  private static selectors = {
+    fileInput: '#file-upload',
+    uploadButton: '#file-submit',
+    resultOutput: '#uploaded-files',
+    errorMessage: 'h1'
+  };
+
+  // Page Functions
+  static visit() {
+    return cy.visit(this.details.pageUrl);
+  }
+
+  static chooseFile(fileName: string) {
+    return cy
+      .get(this.selectors.fileInput)
+      .selectFile({ contents: `cypress/data/files/${fileName}` });
+  }
+
+  static clickUploadButton() {
+    return cy.get(this.selectors.uploadButton).click();
+  }
+
+  static getResultOutput() {
+    return cy.get(this.selectors.resultOutput);
+  }
+
+  static getErrorMessage() {
+    return cy.get(this.selectors.errorMessage);
+  }
+}

--- a/cypress/support/page-objects/home.po.ts
+++ b/cypress/support/page-objects/home.po.ts
@@ -1,6 +1,7 @@
 import { ABTestPage } from './ab-testing.po';
 import { AddRemoveElemPage } from './add-remove-elements.po';
 import { BrokenImagesPage } from './broken-images.po';
+import { FileUploadPage } from './file-upload.po';
 import { FormAuthPage } from './form-auth.po';
 
 export class HomePage {
@@ -12,6 +13,7 @@ export class HomePage {
     ABTestPage.details,
     AddRemoveElemPage.details,
     BrokenImagesPage.details,
+    FileUploadPage.details,
     FormAuthPage.details
   ];
 }

--- a/cypress/tests/file-upload.cy.ts
+++ b/cypress/tests/file-upload.cy.ts
@@ -1,0 +1,33 @@
+import { FileUploadPage } from '../support/page-objects/file-upload.po';
+
+const TEST_FILE = 'TestUploadFile.txt'; // Context directory is cypress/data/files/
+
+describe('File Upload Page Functionality', () => {
+  beforeEach(() => {
+    // Go to file upload page
+    FileUploadPage.visit();
+  });
+
+  it('Should successfully upload file', () => {
+    // Select file to put into dropdown
+    FileUploadPage.chooseFile(TEST_FILE);
+
+    // Click upload button
+    FileUploadPage.clickUploadButton();
+
+    // Assert success state
+    FileUploadPage.getResultOutput()
+      .should('be.visible')
+      .and('contain.text', TEST_FILE);
+  });
+
+  it('Should error when uploading with no file input', () => {
+    // Click upload button, without entering file
+    FileUploadPage.clickUploadButton();
+
+    // Assert error state
+    FileUploadPage.getErrorMessage()
+      .should('be.visible')
+      .and('contain.text', FileUploadPage.ERROR_TEXT);
+  });
+});


### PR DESCRIPTION
Resolves #24 

The following was changed as part of this ticket:
- Addition of test txt file for upload test
- Slight restructure of page object files to have a commented section for all miscellaneous 'Page Data'
- Addition of page object spec & associated page object
- Addition of FileUploadPage to the home page object