### PR TITLE
#29: Add new page object and spec file for file-download page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 cypress.env.json
+downloads/
+screenshots/

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,15 +8,15 @@ export default defineConfig({
     setupNodeEvents(on, config) {
       on('task', {
         checkFileExists(filePath: string) {
-          let something = fs.existsSync(filePath);
-          console.log(something);
-          return something;
+          return fs.existsSync(filePath);
         },
         deleteDownloads() {
           try {
+            // Try: Remove the downloads folder
             fs.rmSync('./cypress/downloads/', { recursive: true });
             return true;
           } catch {
+            // Catch: Downloads folder doesn't exist. Return and keep going
             return true;
           }
         }

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,8 +1,26 @@
 import { defineConfig } from 'cypress';
+import * as fs from 'fs';
 
 export default defineConfig({
   e2e: {
     baseUrl: 'https://the-internet.herokuapp.com/',
-    specPattern: 'cypress/tests/*.cy.ts'
+    specPattern: 'cypress/tests/*.cy.ts',
+    setupNodeEvents(on, config) {
+      on('task', {
+        checkFileExists(filePath: string) {
+          let something = fs.existsSync(filePath);
+          console.log(something);
+          return something;
+        },
+        deleteDownloads() {
+          try {
+            fs.rmSync('./cypress/downloads/', { recursive: true });
+            return true;
+          } catch {
+            return true;
+          }
+        }
+      });
+    }
   }
 });

--- a/cypress/support/page-objects/file-download.po.ts
+++ b/cypress/support/page-objects/file-download.po.ts
@@ -1,0 +1,29 @@
+export class FileDownloadPage {
+  // Page Details
+  static details: PageDetails = {
+    linkText: 'File Download',
+    pageUrl: 'download'
+  };
+
+  // Page Selectors
+  private static selectors = {
+    downloadLink: 'a[href*="download"]'
+  };
+
+  // Page Functions
+  static visit() {
+    return cy.visit(this.details.pageUrl);
+  }
+
+  static downloadFile(fileName: string) {
+    return cy.regexFormat(fileName).then((formattedFileName) => {
+      cy.get(this.selectors.downloadLink)
+        .contains(new RegExp(`^${formattedFileName}$`)) // Regular expression allows for exact matching of file name
+        .click();
+    });
+  }
+
+  static getAvailableFiles() {
+    return cy.get(this.selectors.downloadLink);
+  }
+}

--- a/cypress/support/page-objects/file-download.po.ts
+++ b/cypress/support/page-objects/file-download.po.ts
@@ -16,14 +16,16 @@ export class FileDownloadPage {
   }
 
   static downloadFile(fileName: string) {
-    return cy.regexFormat(fileName).then((formattedFileName) => {
-      cy.get(this.selectors.downloadLink)
-        .contains(new RegExp(`^${formattedFileName}$`)) // Regular expression allows for exact matching of file name
-        .click();
-    });
+    cy.get(this.selectors.downloadLink)
+      .contains(new RegExp(`^${this.formatRegex(fileName)}$`)) // Regular expression allows for exact matching of file name
+      .click();
   }
 
   static getAvailableFiles() {
     return cy.get(this.selectors.downloadLink);
+  }
+
+  private static formatRegex(text: string) {
+    return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // Format special characters for use in regular expressions
   }
 }

--- a/cypress/support/utility.ts
+++ b/cypress/support/utility.ts
@@ -4,28 +4,30 @@ declare global {
   namespace Cypress {
     interface Chainable {
       /**
-       * Wrap a new array with length of the parameter num. Useful for looping actions
-       * @example cy.loop(10).each(() => { ... })
+       * Asserts that the `fileName` provided exists as a file within the Cypress downloads folder.
+       * Recursively runs with a default 15 second timeout. Can be altered with optional `retries` param
+       * @param fileName string: Expected download file name
+       * @param retries number: Wait timeout, in seconds (default 15)
+       *
+       * @example
+       * // Download example.txt file, then...
+       * cy.assertFileDownload('example.txt')
        */
-      loop(times: number): Chainable<any[]>;
-
-      regexFormat(text: string): Chainable<string>;
-
       assertFileDownload(
         fileName: string,
         retries?: number
       ): Chainable<boolean>;
+
+      /**
+       * Wrap a new array with length of the parameter num. Useful for looping actions
+       * @param times number: Number of times you would like to loop
+       * @example
+       * cy.loop(10).each(() => { ... })
+       */
+      loop(times: number): Chainable<any[]>;
     }
   }
 }
-
-Cypress.Commands.add('loop', (times: number) => {
-  cy.wrap(new Array(times));
-});
-
-Cypress.Commands.add('regexFormat', (text: string) => {
-  return cy.wrap(text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-});
 
 Cypress.Commands.add(
   'assertFileDownload',
@@ -44,3 +46,7 @@ Cypress.Commands.add(
     });
   }
 );
+
+Cypress.Commands.add('loop', (times: number) => {
+  cy.wrap(new Array(times));
+});

--- a/cypress/support/utility.ts
+++ b/cypress/support/utility.ts
@@ -8,6 +8,13 @@ declare global {
        * @example cy.loop(10).each(() => { ... })
        */
       loop(times: number): Chainable<any[]>;
+
+      regexFormat(text: string): Chainable<string>;
+
+      assertFileDownload(
+        fileName: string,
+        retries?: number
+      ): Chainable<boolean>;
     }
   }
 }
@@ -15,3 +22,25 @@ declare global {
 Cypress.Commands.add('loop', (times: number) => {
   cy.wrap(new Array(times));
 });
+
+Cypress.Commands.add('regexFormat', (text: string) => {
+  return cy.wrap(text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+});
+
+Cypress.Commands.add(
+  'assertFileDownload',
+  (fileName: string, retries: number = 15) => {
+    cy.task(
+      'checkFileExists',
+      `${Cypress.config().downloadsFolder}/${fileName}`
+    ).then((exists) => {
+      if (exists) {
+        return true;
+      } else if (!retries) {
+        throw Error('File was never downloaded');
+      } else {
+        return cy.wait(1000).assertFileDownload(fileName, retries - 1);
+      }
+    });
+  }
+);

--- a/cypress/tests/file-download.cy.ts
+++ b/cypress/tests/file-download.cy.ts
@@ -7,7 +7,7 @@ describe('File Download Page Functionality', () => {
     FileDownloadPage.visit();
   });
 
-  it('Should download first available file in list', () => {
+  it('Should successfully download first available file in list', () => {
     // Click the first download link on the page
     FileDownloadPage.getAvailableFiles()
       .first()
@@ -21,7 +21,7 @@ describe('File Download Page Functionality', () => {
 
   // This test successfully runs, but is more of a demonstration of what is possible.
   // The dataset on this page is inconsistent, and may occasionally include large files.
-  it.skip('Should download all available files successfully', () => {
+  it.skip('Should successfully download all available files in list', () => {
     // Get all download links on page
     FileDownloadPage.getAvailableFiles().each((file) => {
       // For each, download file and assert successful download

--- a/cypress/tests/file-download.cy.ts
+++ b/cypress/tests/file-download.cy.ts
@@ -1,0 +1,27 @@
+import { FileDownloadPage } from '../support/page-objects/file-download.po';
+
+const DOWNLOAD_FILEPATH = Cypress.config().downloadsFolder;
+
+describe('File Download Page Functionality', () => {
+  beforeEach(() => {
+    cy.task('deleteDownloads');
+    FileDownloadPage.visit();
+  });
+
+  it('Should download first available file in list', () => {
+    FileDownloadPage.getAvailableFiles()
+      .first()
+      .click()
+      .invoke('text')
+      .then((fileName) => {
+        cy.assertFileDownload(fileName);
+      });
+  });
+
+  it('Should download all available files successfully', () => {
+    FileDownloadPage.getAvailableFiles().each((file) => {
+      FileDownloadPage.downloadFile(file.text());
+      cy.assertFileDownload(file.text());
+    });
+  });
+});

--- a/cypress/tests/file-download.cy.ts
+++ b/cypress/tests/file-download.cy.ts
@@ -1,25 +1,30 @@
 import { FileDownloadPage } from '../support/page-objects/file-download.po';
 
-const DOWNLOAD_FILEPATH = Cypress.config().downloadsFolder;
-
 describe('File Download Page Functionality', () => {
   beforeEach(() => {
+    // Delete downloads folder and navigate to download page
     cy.task('deleteDownloads');
     FileDownloadPage.visit();
   });
 
   it('Should download first available file in list', () => {
+    // Click the first download link on the page
     FileDownloadPage.getAvailableFiles()
       .first()
       .click()
+      // Grab file text from the link and assert the file exists in download folder
       .invoke('text')
       .then((fileName) => {
         cy.assertFileDownload(fileName);
       });
   });
 
-  it('Should download all available files successfully', () => {
+  // This test successfully runs, but is more of a demonstration of what is possible.
+  // The dataset on this page is inconsistent, and may occasionally include large files.
+  it.skip('Should download all available files successfully', () => {
+    // Get all download links on page
     FileDownloadPage.getAvailableFiles().each((file) => {
+      // For each, download file and assert successful download
       FileDownloadPage.downloadFile(file.text());
       cy.assertFileDownload(file.text());
     });


### PR DESCRIPTION
The following changes were made as part of this ticket:
- Add new page object and spec file for file-download
- Add downloads/ and screenshots/ folders to .gitignore
- Add cy.task functions to the config.ts file
- Add cypress custom commands to the utility.ts commands file
    - Format escapes for regex strings
    - Recursively check for downloaded file